### PR TITLE
타임리프 버전 이슈 수정 및 deprecated 표현식 수정

### DIFF
--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/AdminUserAccountController.java
@@ -1,11 +1,13 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import ch.qos.logback.core.model.Model;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -17,8 +19,10 @@ public class AdminUserAccountController {
     @GetMapping
     public String members(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC)Pageable pageable,
-            Model model
+            ModelMap model,
+            HttpServletRequest httpServletRequest
     ) {
-        return "/admin/members";
+        model.addAttribute("request",httpServletRequest);
+        return "admin/members";
     }
 }

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -1,11 +1,13 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import ch.qos.logback.core.model.Model;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -17,8 +19,10 @@ public class ArticleCommentManagementController {
     @GetMapping
     public String articleComments(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC)Pageable pageable,
-            Model model
+            ModelMap model,
+            HttpServletRequest httpServletRequest
     ) {
-        return "/management/article-comments";
+        model.addAttribute("request",httpServletRequest);
+        return "management/article-comments";
     }
 }

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -1,11 +1,12 @@
 package com.fastcampus.projectboardadmin.controller;
 
-import ch.qos.logback.core.model.Model;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -17,8 +18,10 @@ public class ArticleManagementController {
     @GetMapping
     public String articles(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable,
-            Model model
+            ModelMap model,
+            HttpServletRequest httpServletRequest
             ) {
-        return "/management/articles";
+        model.addAttribute("request",httpServletRequest);
+        return "management/articles";
     }
 }

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -1,11 +1,13 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -17,9 +19,10 @@ public class UserAccountManagementController {
     @GetMapping
     public String userAccounts(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable,
-            Model model
+            ModelMap model,
+            HttpServletRequest httpServletRequest
     ) {
-
+        model.addAttribute("request",httpServletRequest);
         return "management/user-accounts";
     }
 }

--- a/fastcampus-project-board-admin/src/main/resources/templates/admin/members.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/admin/members.th.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('어드민 회원', (~{::#jsgrid-admin-members} ?: ~{}))" />
-    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+    <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+    <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+    <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+    <attr sel="#layout-main" th:replace="~{layouts/layout-main-table :: common_main_table('어드민 회원', (~{::#jsgrid-admin-members} ?: ~{}))}" />
+    <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+    <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+    <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 </thlogic>

--- a/fastcampus-project-board-admin/src/main/resources/templates/error/4xx.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/error/4xx.th.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <thlogic>
-  <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-  <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-  <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-  <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-  <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-  <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+  <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+  <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+  <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+  <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+  <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+  <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 
   <attr sel="#main-header-title" th:text="'에러 페이지'" />
   <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />

--- a/fastcampus-project-board-admin/src/main/resources/templates/error/5xx.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/error/5xx.th.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <thlogic>
-  <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-  <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-  <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-  <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-  <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-  <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+  <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+  <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+  <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+  <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+  <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+  <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 
   <attr sel="#main-header-title" th:text="'에러 페이지'" />
   <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />

--- a/fastcampus-project-board-admin/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -2,27 +2,27 @@
 <thlogic>
   <attr sel="#admin-logo-link" th:href="@{/}" />
   <attr sel="#user-profile" th:href="@{#}" sec:authorize="isAuthenticated()" sec:authentication="principal.nickname" />
-  <attr sel="#management-category" th:classappend="${#request.requestURI.startsWith('/management')} ? 'active'" />
+  <attr sel="#management-category" th:classappend="${request.requestURI.startsWith('/management')} ? 'active'" />
   <attr
       sel="#article-management"
       th:href="@{/management/articles}"
-      th:classappend="${#request.requestURI.equals('/management/articles')} ? 'active'"
+      th:classappend="${request.requestURI.equals('/management/articles')} ? 'active'"
   />
   <attr
       sel="#article-comment-management"
       th:href="@{/management/article-comments}"
-      th:classappend="${#request.requestURI.equals('/management/article-comments')} ? 'active'"
+      th:classappend="${request.requestURI.equals('/management/article-comments')} ? 'active'"
   />
   <attr
       sel="#user-account-management"
       th:href="@{/management/user-accounts}"
-      th:classappend="${#request.requestURI.equals('/management/user-accounts')} ? 'active'"
+      th:classappend="${request.requestURI.equals('/management/user-accounts')} ? 'active'"
   />
-  <attr sel="#admin-category" th:classappend="${#request.requestURI.startsWith('/admin')} ? 'active'" />
+  <attr sel="#admin-category" th:classappend="${request.requestURI.startsWith('/admin')} ? 'active'" />
   <attr
       sel="#admin-members"
       th:href="@{/admin/members}"
-      th:classappend="${#request.requestURI.equals('/admin/members')} ? 'active'"
+      th:classappend="${request.requestURI.equals('/admin/members')} ? 'active'"
   />
 
   <attr sel="#visit-count" th:text="${visitCount}" />

--- a/fastcampus-project-board-admin/src/main/resources/templates/layouts/layout-main-table.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/layouts/layout-main-table.th.xml
@@ -6,6 +6,6 @@
   <attr sel="#breadcrumb-current-page" th:text="${title}" />
   <attr sel="#card-title" th:text="|${title} 게시판|" />
   <attr sel="#main-table" th:replace="${table}" />
-  <attr sel="#layout-card-todolist" th:replace="layouts/layout-card-todolist :: #layout-card-todolist" />
-  <attr sel="#layout-card-chat" th:replace="layouts/layout-card-chat :: #layout-card-chat" />
+  <attr sel="#layout-card-todolist" th:replace="~{layouts/layout-card-todolist :: #layout-card-todolist}" />
+  <attr sel="#layout-card-chat" th:replace="~{layouts/layout-card-chat :: #layout-card-chat}" />
 </thlogic>

--- a/fastcampus-project-board-admin/src/main/resources/templates/management/article-comments.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/management/article-comments.th.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('댓글 관리', (~{::#main-table} ?: ~{}))" />
-    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+    <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+    <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+    <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+    <attr sel="#layout-main" th:replace="~{layouts/layout-main-table :: common_main_table('댓글 관리', (~{::#main-table} ?: ~{}))}" />
+    <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+    <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+    <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 </thlogic>

--- a/fastcampus-project-board-admin/src/main/resources/templates/management/articles.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/management/articles.th.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('게시글 관리', (~{::#main-table} ?: ~{}))" />
-    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+    <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+    <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+    <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+    <attr sel="#layout-main" th:replace="~{layouts/layout-main-table :: common_main_table('게시글 관리', (~{::#main-table} ?: ~{}))}" />
+    <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+    <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+    <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 </thlogic>

--- a/fastcampus-project-board-admin/src/main/resources/templates/management/user-accounts.th.xml
+++ b/fastcampus-project-board-admin/src/main/resources/templates/management/user-accounts.th.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
-    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
-    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('회원 관리', (~{::#main-table} ?: ~{}))" />
-    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
-    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
-    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+    <attr sel="#layout-head" th:replace="~{layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))}" />
+    <attr sel="#layout-header" th:replace="~{layouts/layout-header :: header}" />
+    <attr sel="#layout-left-aside" th:replace="~{layouts/layout-left-aside :: aside}" />
+    <attr sel="#layout-main" th:replace="~{layouts/layout-main-table :: common_main_table('회원 관리', (~{::#main-table} ?: ~{}))}" />
+    <attr sel="#layout-right-aside" th:replace="~{layouts/layout-right-aside :: aside}" />
+    <attr sel="#layout-footer" th:replace="~{layouts/layout-footer :: footer}" />
+    <attr sel="#layout-scripts" th:replace="~{layouts/layout-scripts :: script}" />
 </thlogic>


### PR DESCRIPTION
replace 표현식은 `~{}` 에 감싸지도록 수정하고,
기존에 ${#request.requestURI~~~} 이런식으로 URI에 접근했다면, 컨트롤러에서 HttpServletRequest 객체를 화면으로 넘겨줘서
${request.requestURI~~~} 에 접근할 수 있도록 코드를 수정함.