### PR TITLE
테이블명 변경 : user_account -> admin_account

### DIFF
--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -20,7 +20,7 @@ import java.util.Set;
         @Index(columnList = "createUser")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id
     @Column(length = 50)
     private String userId;
@@ -57,9 +57,9 @@ public class UserAccount extends AuditingFields {
     private String memo;
 
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createUser) {
+    private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createUser) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.roleTypes = roleTypes;
@@ -80,8 +80,8 @@ public class UserAccount extends AuditingFields {
      * @param memo
      * @return
      */
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccount.of(userId, userPassword, roleTypes, email, nickname, memo, null);
     }
 
     /**
@@ -95,8 +95,8 @@ public class UserAccount extends AuditingFields {
      * @param createUser
      * @return
      */
-    public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createUser) {
-        return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createUser);
+    public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createUser) {
+        return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createUser);
     }
 
     public void deleteRoleType(RoleType roleType) {
@@ -114,7 +114,7 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount that)) return false;
+        if (!(o instanceof AdminAccount that)) return false;
         return userId != null && userId.equals(that.getUserId());
     }
 

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,56 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createDate,
+        String createUser,
+        LocalDateTime updateDate,
+        String updateUser
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createDate, String createUser, LocalDateTime updateDate, String updateUser) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createDate, createUser, updateDate, updateUser);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreateDate(),
+                entity.getCreateUser(),
+                entity.getUpdateDate(),
+                entity.getUpdateUser()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +8,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,38 +18,11 @@ public record UserAccountDto(
         String updateUser
 ) {
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createDate, String createUser, LocalDateTime updateDate, String updateUser) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createDate, createUser, updateDate, updateUser);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createDate, String createUser, LocalDateTime updateDate, String updateUser) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createDate, createUser, updateDate, updateUser);
     }
-
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreateDate(),
-                entity.getCreateUser(),
-                entity.getUpdateDate(),
-                entity.getUpdateUser()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
-    }
-
 }

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -47,7 +47,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto){
+    public static BoardAdminPrincipal from(AdminAccountDto dto){
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -58,8 +58,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto(){
-        return UserAccountDto.of(
+    public AdminAccountDto toDto(){
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+}

--- a/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/fastcampus-project-board-admin/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,7 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-}

--- a/fastcampus-project-board-admin/src/main/resources/data.sql
+++ b/fastcampus-project-board-admin/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, create_date, create_user, update_date, update_user) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, create_date, create_user, update_date, update_user) values
 ('uno', '{noop}asdf1234', 'ADMIN', 'hg', 'hg@mail.com', 'I am HG.', now(), 'uno', now(), 'uno'),
 ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
 ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),


### PR DESCRIPTION
user_account -> admin_account 로 어드민 회원 테이블명 변경
통신하려는 게시판 서비스의 회원 도메인명과 이름이 겹친다.